### PR TITLE
Add metadata

### DIFF
--- a/io.github.yuxshao.ptcollab.metainfo.xml
+++ b/io.github.yuxshao.ptcollab.metainfo.xml
@@ -7,6 +7,11 @@
   <summary>Sample-based music editor where you can collaborate with friends!</summary>
   <developer_name>pxtone collab</developer_name>
 
+  <branding>
+    <color type="primary" scheme_preference="light">#4e4b61</color>
+    <color type="primary" scheme_preference="dark">#4e4b61</color>
+  </branding>
+
   <metadata_license>MIT</metadata_license>
   <project_license>MIT</project_license>
   <screenshots>

--- a/io.github.yuxshao.ptcollab.metainfo.xml
+++ b/io.github.yuxshao.ptcollab.metainfo.xml
@@ -3,12 +3,12 @@
   <id>io.github.yuxshao.ptcollab</id>
  
   <name>pxtone Collab</name>
+  <icon type="remote" height="512" width="512">https://raw.githubusercontent.com/yuxshao/ptcollab/master/res/app_icons/scalable/ptcollab.svg</icon>
   <summary>Sample-based music editor where you can collaborate with friends!</summary>
   <developer_name>pxtone collab</developer_name>
-  
+
   <metadata_license>MIT</metadata_license>
   <project_license>MIT</project_license>
-
   <screenshots>
     <screenshot type="default"><image>https://raw.githubusercontent.com/germe-deb/io.github.yuxshao.ptcollab/58ce0534e5fb0d7e230eb196418c9c5ecf4a0208/screenshots/1stscreenshot.png</image></screenshot>
     <screenshot><image>https://raw.githubusercontent.com/germe-deb/io.github.yuxshao.ptcollab/58ce0534e5fb0d7e230eb196418c9c5ecf4a0208/screenshots/2ndscreenshot.png</image></screenshot>


### PR DESCRIPTION
This PR adds <icon> and <branding> to the metainfo.xml

icon is to tell the store frontend to actually show a icon, and branding is for the banner colors that are going to be implemented in flathub.org (and are already implemented in gnome-software)